### PR TITLE
Sugestão: Aproveitamento das props HTML padrão

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -1,13 +1,14 @@
 import { Button as MuiButton, SxProps } from "@mui/material";
 import React from "react";
 
-export interface ButtonProps {
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   children: React.ReactNode;
   disabled?: boolean;
   expanded?: boolean;
   variant?: "text" | "contained";
   color?: "primary" | "transparent" | "feature" | "contrast";
-  type?: "normal" | "rounded";
+  borderStyle?: "normal" | "rounded";
   startIcon?: React.ReactNode;
   onClick?: () => void;
   href?: string;
@@ -16,7 +17,7 @@ export interface ButtonProps {
 const Button: React.FC<ButtonProps> = ({
   children,
   color = "primary",
-  type = "normal",
+  borderStyle = "normal",
   disabled,
   expanded,
   href,
@@ -53,7 +54,7 @@ const Button: React.FC<ButtonProps> = ({
     backgroundColor: backgroundColor,
     color: foregroundColor,
     border: border,
-    borderRadius: type === "rounded" ? 30 : 1,
+    borderRadius: borderStyle === "rounded" ? 30 : 1,
   };
   if (expanded) {
     sx.flex = 1;

--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -24,6 +24,7 @@ const Button: React.FC<ButtonProps> = ({
   startIcon,
   variant = "contained",
   onClick,
+  ...props
 }: ButtonProps) => {
   let backgroundColor = "#212236";
   let foregroundColor = "white";
@@ -69,6 +70,7 @@ const Button: React.FC<ButtonProps> = ({
       disabled={disabled}
       href={href}
       sx={sx}
+      {...props}
     >
       {children}
     </MuiButton>

--- a/components/JobsFilter/JobsFilter.tsx
+++ b/components/JobsFilter/JobsFilter.tsx
@@ -28,23 +28,23 @@ const JobsFilter: React.FC = () => {
             alignItems: "center",
           }}
         >
-          <Button color="contrast" type="rounded">
+          <Button color="contrast" borderStyle="rounded">
             {" "}
             FrontEnd{" "}
           </Button>
-          <Button color="contrast" type="rounded">
+          <Button color="contrast" borderStyle="rounded">
             {" "}
             BackEnd{" "}
           </Button>
-          <Button color="contrast" type="rounded">
+          <Button color="contrast" borderStyle="rounded">
             {" "}
             DevOps{" "}
           </Button>
-          <Button color="contrast" type="rounded">
+          <Button color="contrast" borderStyle="rounded">
             {" "}
             Produtos{" "}
           </Button>
-          <Button color="contrast" type="rounded">
+          <Button color="contrast" borderStyle="rounded">
             {" "}
             Suporte{" "}
           </Button>
@@ -59,7 +59,7 @@ const JobsFilter: React.FC = () => {
           alignItems: "center",
         }}
       >
-        <Button type="rounded">Escolher um local V</Button>
+        <Button borderStyle="rounded">Escolher um local V</Button>
       </Box>
     </Box>
   );


### PR DESCRIPTION
O React permite extender as props de HTML pra permitir aproveitar as props padrão. Essa sugestão permite melhorar a developer experience, pois transforma isso:

https://github.com/dev-pira/site/assets/22418450/eeb095c7-002c-477f-815e-135fc434550a

nisso:
https://github.com/dev-pira/site/assets/22418450/dc5bfca0-e796-4a5f-b2a7-889435aaf080



