### PR TITLE
fix: :rotating_light: Tipo de dado do horario da palestra

### DIFF
--- a/components/EventDetailContent/EventDetailContent.stories.tsx
+++ b/components/EventDetailContent/EventDetailContent.stories.tsx
@@ -32,7 +32,7 @@ for (const track of trackNames) {
         portraitUrl: "",
         job: lorem.generateWords(4),
       },
-      time: now,
+      time: now.toString(),
     });
   }
   props.tracks?.push(res);


### PR DESCRIPTION
Corrigindo o tipo de dado do horario da palestra na documentação do componente. Era considerado DateTime, foi substituido para string para ficar de acordo com o dado do CMS